### PR TITLE
Fix Bernini-R training launcher documentation

### DIFF
--- a/docs/bernini_r_train.md
+++ b/docs/bernini_r_train.md
@@ -127,34 +127,38 @@ uv run python tools/preprocess_data.py \
 
 ### Entry script
 
-`scripts/train_bernini_renderer.sh` invokes the training entrypoint
+`scripts/bernini_r_train/train_bernini_renderer.sh` invokes the training entrypoint
 `tasks/bernini_renderer/train_bernini_renderer.py` via `torchrun`. By default it uses
-`configs/bernini_renderer/train_cfg/bernini_renderer_high.yaml` and forwards extra
-arguments (`"$@"`) to the VeOmni argument parser.
+`configs/bernini_renderer_train/train_cfg/bernini_renderer_high.yaml`. An optional first
+positional argument selects another training config; any remaining arguments are
+forwarded to the VeOmni argument parser.
 
 ```bash
-bash scripts/train_bernini_renderer.sh
+bash scripts/bernini_r_train/train_bernini_renderer.sh
 # Override config items, for example:
-bash scripts/train_bernini_renderer.sh --train.max_steps 1000
+bash scripts/bernini_r_train/train_bernini_renderer.sh --train.max_steps 1000
 # Switch to the low-noise expert:
-bash scripts/train_bernini_renderer.sh \
-  configs/bernini_renderer/train_cfg/bernini_renderer_low.yaml
+bash scripts/bernini_r_train/train_bernini_renderer.sh \
+  configs/bernini_renderer_train/train_cfg/bernini_renderer_low.yaml
 ```
 
-The script automatically infers the distributed topology from environment variables:
+Run the script from the repository root. Its distributed topology is configured by
+environment variables:
 
-- `NNODES` / `NPROC_PER_NODE` / `NODE_RANK` / `MASTER_ADDR` / `MASTER_PORT`; if not set
-  it falls back to a single host with the visible GPU count;
-- It sets `NCCL_P2P_LEVEL=NVL` and similar parameters, and clears network-plugin
-  related environment variables that could interfere with NCCL initialization;
-- Before launching, it prepends `VeOmni/` and the project root to `PYTHONPATH`.
+- `NNODES`, `NPROC_PER_NODE`, and `NODE_RANK` default to `1`, `8`, and `0`;
+- `MASTER_ADDR` and `MASTER_PORT` default to `127.0.0.1` and `29501`;
+- it clears `NCCL_NET_PLUGIN`, `NCCL_NET_GCP_FASTRAK`, and
+  `NCCL_NET_PLUGIN_PATH`, then checks CUDA availability and PyTorch FSDP2 support
+  before launching `torchrun`.
 
-If you manage the environment with `uv`, you can prepend `uv run` to the script or first
-run `source .venv/bin/activate`.
+Override the topology variables explicitly when the machine does not have eight visible
+GPUs or when launching across multiple nodes. If you manage the environment with `uv`,
+run `uv run bash scripts/bernini_r_train/train_bernini_renderer.sh` or first activate
+the virtual environment.
 
 ### Config files
 
-The training configs live under `configs/bernini_renderer/`:
+The training configs live under `configs/bernini_renderer_train/`:
 
 - `train_cfg/bernini_renderer_high.yaml`: High-noise expert
   (`skip_transformer_2: true`, `noise_tmin/tmax = 0.875/1.0`,
@@ -162,7 +166,6 @@ The training configs live under `configs/bernini_renderer/`:
 - `train_cfg/bernini_renderer_low.yaml`: Low-noise expert
   (`skip_transformer_1: true`, `noise_tmin/tmax = 0.0/0.875`,
   `output_dir: bernini_renderer_train_low`);
-- `train_cfg/bernini_renderer_test.yaml`: minimal config used for smoke testing;
 - `data_cfg/example_weighted_multisource.yaml`: example multi-source weighted data
   config. The `name` field uses the `<task>$<dataset>` convention to identify the task
   type (`t2i`, `t2v`, `i2i`, `r2i`, `r2v`, `v2v`, `i2v`, `vi2v`, `vr2v`, `vrc2v`,

--- a/scripts/bernini_r_train/train_bernini_renderer.sh
+++ b/scripts/bernini_r_train/train_bernini_renderer.sh
@@ -26,6 +26,12 @@ MASTER_ADDR=${MASTER_ADDR:-127.0.0.1}
 MASTER_PORT=${MASTER_PORT:-29501}
 MASTER_PORT=${MASTER_PORT%%,*}
 
+TRAIN_CONFIG=configs/bernini_renderer_train/train_cfg/bernini_renderer_high.yaml
+if [[ $# -gt 0 && "$1" != -* ]]; then
+  TRAIN_CONFIG=$1
+  shift
+fi
+
 python - <<'PY'
 import torch
 import torch.distributed.fsdp as fsdp
@@ -46,5 +52,5 @@ torchrun \
   --master-addr="$MASTER_ADDR" \
   --master-port="$MASTER_PORT" \
   tasks/bernini_renderer/train_bernini_renderer.py \
-  configs/bernini_renderer_train/train_cfg/bernini_renderer_high.yaml \
+  "$TRAIN_CONFIG" \
   "$@"

--- a/tests/test_training_launcher.py
+++ b/tests/test_training_launcher.py
@@ -1,0 +1,117 @@
+# Copyright (c) 2026 Bytedance Ltd. and/or its affiliate
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from pathlib import Path
+import shutil
+import stat
+import subprocess
+import tempfile
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+LAUNCHER = Path("scripts/bernini_r_train/train_bernini_renderer.sh")
+DEFAULT_CONFIG = "configs/bernini_renderer_train/train_cfg/bernini_renderer_high.yaml"
+LOW_CONFIG = "configs/bernini_renderer_train/train_cfg/bernini_renderer_low.yaml"
+
+
+def find_bash() -> str | None:
+    candidates: list[Path] = []
+    if os.name == "nt":
+        git = shutil.which("git")
+        if git:
+            candidates.append(Path(git).resolve().parent.parent / "bin" / "bash.exe")
+    if bash := shutil.which("bash"):
+        candidates.append(Path(bash))
+
+    for candidate in candidates:
+        try:
+            result = subprocess.run(
+                [str(candidate), "--version"],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                check=False,
+            )
+        except OSError:
+            continue
+        if result.returncode == 0:
+            return str(candidate)
+    return None
+
+
+class TrainingLauncherTest(unittest.TestCase):
+    def run_launcher(self, *arguments: str) -> list[str]:
+        bash = find_bash()
+        if bash is None:
+            self.skipTest("bash is required to exercise the training launcher")
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            bin_dir = Path(temp_dir, "bin")
+            bin_dir.mkdir()
+            trace_file = Path(temp_dir, "torchrun-args.txt")
+
+            self.write_stub(
+                bin_dir / "python",
+                "#!/usr/bin/env bash\ncat >/dev/null\n",
+            )
+            self.write_stub(
+                bin_dir / "torchrun",
+                '#!/usr/bin/env bash\nprintf \'%s\\n\' "$@" > "$TRACE_FILE"\n',
+            )
+
+            environment = os.environ.copy()
+            environment["PATH"] = os.pathsep.join(
+                [str(bin_dir), environment.get("PATH", "")]
+            )
+            environment["TRACE_FILE"] = trace_file.as_posix()
+
+            completed = subprocess.run(
+                [bash, str(LAUNCHER), *arguments],
+                cwd=REPO_ROOT,
+                env=environment,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(0, completed.returncode, completed.stderr)
+            return trace_file.read_text(encoding="utf-8").splitlines()
+
+    @staticmethod
+    def write_stub(path: Path, contents: str) -> None:
+        path.write_text(contents, encoding="utf-8", newline="\n")
+        path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+    def test_default_config_is_followed_by_overrides(self) -> None:
+        arguments = self.run_launcher("--train.max_steps", "10")
+
+        self.assertEqual(
+            [DEFAULT_CONFIG],
+            [argument for argument in arguments if argument.endswith(".yaml")],
+        )
+        self.assertEqual(["--train.max_steps", "10"], arguments[-2:])
+
+    def test_explicit_config_replaces_default(self) -> None:
+        arguments = self.run_launcher(LOW_CONFIG, "--train.max_steps", "10")
+
+        self.assertEqual(
+            [LOW_CONFIG],
+            [argument for argument in arguments if argument.endswith(".yaml")],
+        )
+        self.assertNotIn(DEFAULT_CONFIG, arguments)
+        self.assertEqual(["--train.max_steps", "10"], arguments[-2:])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- accept an optional training config as the launcher's first positional argument while retaining the high-noise default
- correct the training guide's launcher/config paths, low-noise invocation, and documented runtime behavior
- add regression coverage for default and explicit config selection with stubbed launcher dependencies

## Tests
- `python -B -m unittest discover -s tests -p 'test_training_launcher.py' -v`
- `C:\Program Files\Git\bin\bash.exe -n scripts/bernini_r_train/train_bernini_renderer.sh`
- PowerShell validation of all 5 tracked Markdown files' local links and the 4 documented launcher/config/task paths
- `git diff --check upstream/main..HEAD`

Fixes #47