### PR TITLE
Correct image launcher topology in guide

### DIFF
--- a/docs/bernini.md
+++ b/docs/bernini.md
@@ -57,8 +57,9 @@ export BERNINI_CONFIG=/path/to/Bernini-Diffusers
 
 The recommended way to run Bernini is through the ready-to-run launch scripts
 under [`scripts/bernini/`](../scripts/bernini/). These scripts wrap the
-single-GPU image path and the multi-GPU video path with the appropriate default
-case files, sampling hyperparameters, and Ulysses sequence-parallel settings.
+image and video paths in configurable multi-process launches with the
+appropriate default case files, sampling hyperparameters, and Ulysses
+sequence-parallel settings.
 
 Inputs are described by case files under
 [`assets/testcases/`](../assets/testcases/); see the


### PR DESCRIPTION
## Summary
- describe the image and video task scripts as configurable multi-process launchers
- align the prose with the documented and implemented 8-process / Ulysses-8 defaults

## Validation
- PowerShell validation of all 5 tracked Markdown files' local links
- topology check for the 6 documented task launchers (`NPROC_PER_NODE=8`, `ULYSSES=8`, and `torchrun`)
- stale-claim check for `single-GPU image path`
- `git diff --check upstream/main..HEAD`

Fixes #54