### PR TITLE
Fix checkpoint table rendering

### DIFF
--- a/docs/bernini.md
+++ b/docs/bernini.md
@@ -8,7 +8,7 @@ instructions and plans semantic changes in latent space before diffusion
 rendering, which gives stronger instruction following on complex
 generation/editing requests than the renderer-only [Bernini-R](bernini_r.md).
 
-｜ Checkpoint | Renderer base | Planner base | Notes |
+| Checkpoint | Renderer base | Planner base | Notes |
 | ------- | ------- | ------- | ------- |
 | [`ByteDance/Bernini-Diffusers`](https://huggingface.co/ByteDance/Bernini-Diffusers) | Wan2.2-T2V-A14B | Qwen2.5-VL-7B-Instruct | Cotrain starts with a near-zero initialized connector. |
 | [`ByteDance/Bernini-Diffusers-v2`](https://huggingface.co/ByteDance/Bernini-Diffusers-v2) | Wan2.2-T2V-A14B | Qwen2.5-VL-7B-Instruct | Warm up the connector for thousands of steps before cotraining. |


### PR DESCRIPTION
## Summary
- replace the fullwidth leading delimiter with an ASCII Markdown pipe
- restore four-column rendering for the checkpoint comparison table

## Validation
- checkpoint-table structure check: 4 rows, 4 columns, ASCII leading/trailing delimiters
- PowerShell validation of all 5 tracked Markdown files' local links
- `git diff --check upstream/main..HEAD`

Fixes #56