### PR TITLE
Initialize W&B before logging resumed training

### DIFF
--- a/tasks/bernini_renderer/train_bernini_renderer.py
+++ b/tasks/bernini_renderer/train_bernini_renderer.py
@@ -531,6 +531,20 @@ def main():
         torch.set_rng_state(state["extra_state"]["torch_rng_state"])
         dist.barrier()
 
+    wandb_module = None
+    wandb_run = None
+    if args.train.global_rank == 0 and args.train.wandb.enable:
+        import wandb
+
+        wandb_module = wandb
+        wandb_run = wandb.init(
+            project=args.train.wandb.project,
+            name=args.train.wandb.name,
+            id=args.train.wandb.id,
+            resume="allow" if args.train.wandb.id else None,
+            config=asdict(args),
+        )
+
     model_fwd_context, model_bwd_context = build_activation_offloading_context(
         args.train.accelerator.offload_config.enable_activation,
         args.train.gradient_checkpointing.enable,
@@ -616,20 +630,10 @@ def main():
             pbar.set_postfix_str(postfix_str, refresh=False)
             pbar.update()
 
-            if args.train.global_rank == 0 and args.train.wandb.enable:
-                import wandb
-
-                if global_step == 1:
-                    wandb.init(
-                        project=args.train.wandb.project,
-                        name=args.train.wandb.name,
-                        id=args.train.wandb.id,
-                        resume="allow" if args.train.wandb.id else None,
-                        config=asdict(args),
-                    )
+            if wandb_run is not None:
                 train_metrics.update({f"training/{k}": v for k, v in log_losses.items()})
                 train_metrics.update({"training/loss": total_loss, "training/grad_norm": grad_norm, "training/lr": max(lr_scheduler.get_last_lr())})
-                wandb.log(train_metrics, step=global_step)
+                wandb_run.log(train_metrics, step=global_step)
 
             if args.train.checkpoint.save_steps and global_step % args.train.checkpoint.save_steps == 0:
                 save_path = os.path.join(args.train.checkpoint.save_path, f"global_step_{global_step}")
@@ -649,10 +653,8 @@ def main():
         pbar.close()
         start_step = 0
     synchronize()
-    if args.train.global_rank == 0 and args.train.wandb.enable:
-        import wandb
-
-        wandb.finish()
+    if wandb_module is not None:
+        wandb_module.finish()
 
 
 if __name__ == "__main__":

--- a/tests/test_wandb_resume.py
+++ b/tests/test_wandb_resume.py
@@ -1,0 +1,60 @@
+"""Regression checks for W&B initialization on fresh and resumed training."""
+
+import ast
+from pathlib import Path
+import unittest
+
+
+SOURCE = Path(__file__).parents[1] / "tasks" / "bernini_renderer" / "train_bernini_renderer.py"
+
+
+class WandbResumeTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.tree = ast.parse(SOURCE.read_text(encoding="utf-8"))
+        cls.main = next(node for node in cls.tree.body if isinstance(node, ast.FunctionDef) and node.name == "main")
+
+    def test_init_is_outside_training_step_loop(self):
+        init_nodes = [
+            node
+            for node in ast.walk(self.main)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "init"
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "wandb"
+        ]
+        self.assertEqual(len(init_nodes), 1)
+        train_loop = next(
+            node
+            for node in ast.walk(self.main)
+            if isinstance(node, ast.For)
+            and isinstance(node.target, ast.Name)
+            and node.target.id == "epoch"
+        )
+        self.assertLess(init_nodes[0].lineno, train_loop.lineno)
+
+    def test_logging_uses_initialized_run(self):
+        log_calls = [
+            node
+            for node in ast.walk(self.main)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "log"
+        ]
+        self.assertEqual(len(log_calls), 1)
+        self.assertIsInstance(log_calls[0].func.value, ast.Name)
+        self.assertEqual(log_calls[0].func.value.id, "wandb_run")
+        guards = [
+            node
+            for node in ast.walk(self.main)
+            if isinstance(node, ast.If)
+            and isinstance(node.test, ast.Compare)
+            and isinstance(node.test.left, ast.Name)
+            and node.test.left.id == "wandb_run"
+        ]
+        self.assertTrue(any(isinstance(node.test.ops[0], ast.IsNot) for node in guards))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- initialize the rank-0 W&B run after checkpoint restoration and before training
- log through the initialized run so fresh and resumed jobs share the same path
- finish W&B only when a run was initialized
- add AST regression checks for initialization placement and guarded logging

## Tests

- `python -B -m unittest tests/test_wandb_resume.py -v`
- `python -m compileall -q tasks/bernini_renderer/train_bernini_renderer.py tests/test_wandb_resume.py`
- `git diff --check`

Fixes #60
