### PR TITLE
Preserve planner predictions for mask index zero

### DIFF
--- a/bernini/pipeline.py
+++ b/bernini/pipeline.py
@@ -812,11 +812,12 @@ class BerniniPipeline:
                     mask_to_pred = torch.logical_xor(mask.bool(), mask_next)
                 mask = mask_next
 
-                if mask_to_pred.nonzero(as_tuple=True)[0].sum() == 0:
-                    continue 
-                cond_pred_vit_embed = pred_vit_embed_mllm[:, mask_to_pred.nonzero(as_tuple=True)[0]]
-                uncond_pred_vit_embed = uncond_pred_vit_embed_mllm[:, mask_to_pred.nonzero(as_tuple=True)[0]]
-                imgcond_pred_vit_embed = imgcond_pred_vit_embed_mllm[:, mask_to_pred.nonzero(as_tuple=True)[0]]
+                pred_indices = mask_to_pred.nonzero(as_tuple=True)[0]
+                if pred_indices.numel() == 0:
+                    continue
+                cond_pred_vit_embed = pred_vit_embed_mllm[:, pred_indices]
+                uncond_pred_vit_embed = uncond_pred_vit_embed_mllm[:, pred_indices]
+                imgcond_pred_vit_embed = imgcond_pred_vit_embed_mllm[:, pred_indices]
                 cur_pred_vit_embed = self.sample_vit_decoder(
                     vit_embed=cond_pred_vit_embed,
                     uncond_vit_embed=uncond_pred_vit_embed,
@@ -828,7 +829,7 @@ class BerniniPipeline:
                 )
 
                 all_target_vit_embed = input_embeds[:, visual_output_token_mask, :]
-                all_target_vit_embed[:, mask_to_pred.nonzero(as_tuple=True)[0]] = cur_pred_vit_embed
+                all_target_vit_embed[:, pred_indices] = cur_pred_vit_embed
                 input_embeds[:, visual_output_token_mask] = all_target_vit_embed
                 uncond_input_embeds[:, uncond_visual_output_token_mask] = all_target_vit_embed
                 imgcond_input_embeds[:, imgcond_visual_output_token_mask] = all_target_vit_embed

--- a/tests/test_mask_selection.py
+++ b/tests/test_mask_selection.py
@@ -1,0 +1,33 @@
+"""Regression checks for planner prediction-mask selection."""
+
+import ast
+from pathlib import Path
+import unittest
+
+import torch
+
+
+SOURCE = Path(__file__).parents[1] / "bernini" / "pipeline.py"
+
+
+class MaskSelectionTests(unittest.TestCase):
+    def test_empty_and_singleton_index_zero_masks_are_distinguished(self):
+        empty = torch.zeros(4, dtype=torch.bool).nonzero(as_tuple=True)[0]
+        singleton_zero = torch.tensor([True, False, False, False]).nonzero(as_tuple=True)[0]
+
+        self.assertEqual(empty.numel(), 0)
+        self.assertEqual(singleton_zero.tolist(), [0])
+        self.assertNotEqual(singleton_zero.numel(), 0)
+
+    def test_pipeline_uses_index_count_for_empty_check(self):
+        tree = ast.parse(SOURCE.read_text(encoding="utf-8"))
+        source = SOURCE.read_text(encoding="utf-8")
+
+        self.assertIn("pred_indices = mask_to_pred.nonzero(as_tuple=True)[0]", source)
+        self.assertIn("if pred_indices.numel() == 0:", source)
+        self.assertNotIn("mask_to_pred.nonzero(as_tuple=True)[0].sum()", source)
+        self.assertIsNotNone(tree)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- cache planner prediction indices once per iteration
- use the selected index count to distinguish empty masks from singleton index 0
- add regression coverage for empty, index-zero, and source-level selection behavior

## Tests

- `python -B -m unittest tests/test_mask_selection.py -v`
- `python -m compileall -q bernini/pipeline.py tests/test_mask_selection.py`
- `git diff --check`

Fixes #62
