### PR TITLE
Skip VAE setup for VIT-only preprocessing

### DIFF
--- a/tests/test_only_vit.py
+++ b/tests/test_only_vit.py
@@ -1,0 +1,45 @@
+"""Regression checks for the VIT-only preprocessing initialization path."""
+
+import ast
+from pathlib import Path
+import unittest
+
+
+SOURCE = Path(__file__).parents[1] / "tools" / "preprocess_data.py"
+
+
+class OnlyVitTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.tree = ast.parse(SOURCE.read_text(encoding="utf-8"))
+        cls.main = next(node for node in cls.tree.body if isinstance(node, ast.FunctionDef) and node.name == "main")
+
+    def test_vae_loader_is_guarded_by_only_vit(self):
+        loader = next(
+            node
+            for node in ast.walk(self.main)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "from_pretrained"
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "AutoencoderKLWan"
+        )
+        guard = next(
+            node
+            for node in ast.walk(self.main)
+            if isinstance(node, ast.If) and node.body and loader in ast.walk(node)
+        )
+        self.assertIsInstance(guard.test, ast.UnaryOp)
+        self.assertIsInstance(guard.test.op, ast.Not)
+        self.assertIsInstance(guard.test.operand, ast.Attribute)
+        self.assertEqual(guard.test.operand.attr, "only_vit")
+
+    def test_vae_state_is_explicitly_empty_before_optional_setup(self):
+        source = SOURCE.read_text(encoding="utf-8")
+        self.assertIn("vae_model = None", source)
+        self.assertIn("vae_transform = None", source)
+        self.assertIn("if not args.only_vit:", source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/preprocess_data.py
+++ b/tools/preprocess_data.py
@@ -266,16 +266,19 @@ def main():
         args.vlm_config, padding_side="right", trust_remote_code=True)
     print('finish creating vit processor')
 
-    vae_model = AutoencoderKLWan.from_pretrained(
-        args.vae_config, torch_dtype=torch.float32)
-    vae_model.eval()
-    vae_model = vae_model.cuda()
-    vae_transform = VAEImageTransform(
-        max_image_size=args.vae_max_image_size,
-        min_image_size=args.vae_min_image_size,
-        image_stride=8*2,
-        max_pixels=args.vae_max_pixels,
-    )
+    vae_model = None
+    vae_transform = None
+    if not args.only_vit:
+        vae_model = AutoencoderKLWan.from_pretrained(
+            args.vae_config, torch_dtype=torch.float32)
+        vae_model.eval()
+        vae_model = vae_model.cuda()
+        vae_transform = VAEImageTransform(
+            max_image_size=args.vae_max_image_size,
+            min_image_size=args.vae_min_image_size,
+            image_stride=8*2,
+            max_pixels=args.vae_max_pixels,
+        )
     print("Models loaded.")
 
     if os.path.isdir(args.input_dir):


### PR DESCRIPTION
## Summary

- skip Wan VAE construction, CUDA transfer, and transform setup for `--only_vit`
- retain the existing VAE path for default preprocessing
- add AST regression checks for the guarded loader and explicit optional state

## Tests

- `python -B -m unittest tests/test_only_vit.py -v`
- `python -m compileall -q tools/preprocess_data.py tests/test_only_vit.py`
- `git diff --check`

Fixes #68
