### PR TITLE
Fix optional Qwen attention branches

### DIFF
--- a/bernini/models/modeling_qwen2_5_vl.py
+++ b/bernini/models/modeling_qwen2_5_vl.py
@@ -56,6 +56,7 @@ import torch.nn.functional as F
 import torch.distributed as dist
 from torch.nn import CrossEntropyLoss
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+from packaging import version
 from transformers.activations import ACT2FN
 from transformers.cache_utils import Cache, DynamicCache, SlidingWindowCache, StaticCache
 from transformers.generation import GenerationMixin
@@ -110,6 +111,16 @@ except ModuleNotFoundError:
 
 def get_flex_qkv_pad_length():
     return int(os.environ.get("FLEX_QKV_PAD_LENGTH", "128"))
+
+
+def _flex_attention_compile_kwargs(torch_version):
+    """Return the torch.compile options supported by a parsed torch version."""
+    if torch_version <= version.parse("2.5.1"):
+        return {"dynamic": False}
+    if torch_version.base_version == "2.6.0":
+        return {"dynamic": False, "mode": "max-autotune-no-cudagraphs"}
+    return {}
+
 
 fa2_installed = importlib.util.find_spec('flash_attn') is not None
 fa3_hopper_installed = importlib.util.find_spec('flash_attn_interface') is not None
@@ -1104,15 +1115,13 @@ class Qwen2_5_VLFlashAttention2(Qwen2_5_VLAttention):
         use_flex_attn = attention_mask is not None and isinstance(
             attention_mask, torch.nn.attention.flex_attention.BlockMask
         )
+        # Flash/Flex attention does not expose attention weights in this path.
+        attn_weights = None
         if use_flex_attn and self.flex_attention is None:
-            if is_torch_less_or_equal("2.5.1", accept_dev=True):
-                self.flex_attention = torch.compile(flex_attention, dynamic=False)
-            elif version.parse(get_torch_version()).base_version == "2.6.0":
-                self.flex_attention = torch.compile(
-                    flex_attention, dynamic=False, mode="max-autotune-no-cudagraphs"
-                )
-            else:
-                self.flex_attention = torch.compile(flex_attention)
+            torch_version = version.parse(torch.__version__.split("+", 1)[0])
+            self.flex_attention = torch.compile(
+                flex_attention, **_flex_attention_compile_kwargs(torch_version)
+            )
 
         bsz, q_len, _ = hidden_states.size()
 

--- a/tests/test_attention_optional_branches.py
+++ b/tests/test_attention_optional_branches.py
@@ -1,0 +1,78 @@
+"""Regression checks for optional Qwen attention branches."""
+
+import ast
+from pathlib import Path
+import unittest
+
+from packaging import version
+
+
+SOURCE = Path(__file__).parents[1] / "bernini" / "models" / "modeling_qwen2_5_vl.py"
+
+
+class OptionalAttentionBranchTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.tree = ast.parse(SOURCE.read_text(encoding="utf-8"))
+        cls.source = SOURCE.read_text(encoding="utf-8")
+        cls.compile_kwargs = cls._load_compile_kwargs(cls.tree)
+        cls.flash_class = next(
+            node
+            for node in cls.tree.body
+            if isinstance(node, ast.ClassDef) and node.name == "Qwen2_5_VLFlashAttention2"
+        )
+        cls.forward = next(
+            node
+            for node in cls.flash_class.body
+            if isinstance(node, ast.FunctionDef) and node.name == "forward"
+        )
+
+    def test_flex_compile_version_checks_use_defined_symbols(self):
+        self.assertIn("from packaging import version", self.source)
+        self.assertIn('torch_version = version.parse(torch.__version__.split("+", 1)[0])', self.source)
+        self.assertNotIn("is_torch_less_or_equal(", self.source)
+        self.assertNotIn("get_torch_version()", self.source)
+
+    def test_flex_compile_options_cover_stable_dev_and_rc_2_6_versions(self):
+        expected_special_case = {
+            "dynamic": False,
+            "mode": "max-autotune-no-cudagraphs",
+        }
+        for value in ("2.6.0", "2.6.0.dev20260101", "2.6.0rc1", "2.6.0+cu128"):
+            with self.subTest(value=value):
+                self.assertEqual(self.__class__.compile_kwargs(version.parse(value)), expected_special_case)
+        self.assertEqual(self.__class__.compile_kwargs(version.parse("2.5.1")), {"dynamic": False})
+        self.assertEqual(self.__class__.compile_kwargs(version.parse("2.6.1")), {})
+
+    def test_flash_forward_initializes_attention_weights(self):
+        initializations = [
+            node
+            for node in self.forward.body
+            if isinstance(node, ast.Assign)
+            and any(isinstance(target, ast.Name) and target.id == "attn_weights" for target in node.targets)
+            and isinstance(node.value, ast.Constant)
+            and node.value.value is None
+        ]
+        self.assertEqual(len(initializations), 1)
+        returns = [node for node in ast.walk(self.forward) if isinstance(node, ast.Return)]
+        self.assertTrue(any(isinstance(node.value, ast.Tuple) for node in returns))
+
+    @staticmethod
+    def _load_compile_kwargs(tree):
+        helper = next(
+            node
+            for node in tree.body
+            if isinstance(node, ast.FunctionDef) and node.name == "_flex_attention_compile_kwargs"
+        )
+        module = ast.Module(
+            body=[ast.ImportFrom(module="packaging", names=[ast.alias(name="version")]), helper],
+            type_ignores=[],
+        )
+        ast.fix_missing_locations(module)
+        namespace = {}
+        exec(compile(module, str(SOURCE), "exec"), namespace)
+        return namespace["_flex_attention_compile_kwargs"]
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- replace undefined flex-attention version helpers with the supported `packaging.version` and torch version
- preserve the `base_version == "2.6.0"` behavior for stable, development, release-candidate, and local builds
- initialize Flash/Flex attention weights to an explicit `None`
- add regression checks for version selection and the attention return value

## Tests

- `python -B -m unittest tests/test_attention_optional_branches.py -v`
- the source helper is exercised with stable, dev, rc, and local 2.6.0 versions, plus the 2.5.1 and 2.6.1 boundaries
- `python -m compileall -q bernini/models/modeling_qwen2_5_vl.py tests/test_attention_optional_branches.py`
- `git diff --check`

The existing module has unrelated baseline Ruff findings, including an earlier undefined helper in another attention path; they are outside this change.

Fixes #67
