### PR TITLE
Reject unrelated renderer checkpoints

### DIFF
--- a/bernini/weights.py
+++ b/bernini/weights.py
@@ -97,14 +97,30 @@ def load_transformer_state_dict(ckpt_path: str, prefixes: list):
     raise ValueError(f"no weights matching prefixes {prefixes} found in {ckpt_path}")
 
 
+def _validate_state_dict_overlap(state_dict: dict, target_state_dict: dict, checkpoint_name: str) -> int:
+    """Require at least one target tensor before doing a non-strict load."""
+    overlap = set(state_dict).intersection(target_state_dict)
+    if not overlap:
+        raise ValueError(
+            f"{checkpoint_name} checkpoint has no keys matching its target transformer"
+        )
+    return len(overlap)
+
+
 def load_weights(model, high_noise_ckpt: str, low_noise_ckpt: str):
     """Load the high-noise and low-noise transformer weights into a BerniniRendererModel."""
     high, prefix = load_transformer_state_dict(high_noise_ckpt, HIGH_NOISE_PREFIXES)
+    high_overlap = _validate_state_dict_overlap(
+        high, model.diff_dec.transformer.state_dict(), "high-noise"
+    )
     miss, unexpected = model.diff_dec.transformer.load_state_dict(high, strict=False, assign=False)
-    logger.info("high-noise: %d tensors via prefix '%s', missing=%d unexpected=%d",
-                len(high), prefix, len(miss), len(unexpected))
+    logger.info("high-noise: %d tensors via prefix '%s', overlap=%d, missing=%d unexpected=%d",
+                len(high), prefix, high_overlap, len(miss), len(unexpected))
 
     low, prefix = load_transformer_state_dict(low_noise_ckpt, LOW_NOISE_PREFIXES)
+    low_overlap = _validate_state_dict_overlap(
+        low, model.diff_dec.transformer_2.state_dict(), "low-noise"
+    )
     miss, unexpected = model.diff_dec.transformer_2.load_state_dict(low, strict=False, assign=False)
-    logger.info("low-noise: %d tensors via prefix '%s', missing=%d unexpected=%d",
-                len(low), prefix, len(miss), len(unexpected))
+    logger.info("low-noise: %d tensors via prefix '%s', overlap=%d, missing=%d unexpected=%d",
+                len(low), prefix, low_overlap, len(miss), len(unexpected))

--- a/tests/test_checkpoint_overlap.py
+++ b/tests/test_checkpoint_overlap.py
@@ -1,0 +1,27 @@
+"""Regression checks for rejecting unrelated transformer checkpoints."""
+
+import unittest
+
+from bernini.weights import _validate_state_dict_overlap
+
+
+class CheckpointOverlapTests(unittest.TestCase):
+    def test_unrelated_checkpoint_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "no keys matching"):
+            _validate_state_dict_overlap(
+                {"totally_unrelated": object()},
+                {"transformer.layer.weight": object()},
+                "high-noise",
+            )
+
+    def test_matching_checkpoint_is_accepted_and_counted(self):
+        overlap = _validate_state_dict_overlap(
+            {"transformer.layer.weight": object(), "extra": object()},
+            {"transformer.layer.weight": object(), "other": object()},
+            "low-noise",
+        )
+        self.assertEqual(overlap, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- reject high- or low-noise checkpoint state dicts with no target-key overlap
- retain non-strict loading for valid partial checkpoints
- log accepted overlap counts and add synthetic unrelated-checkpoint coverage

## Tests

- `python -B -m unittest tests/test_checkpoint_overlap.py -v`
- `python -m compileall -q bernini/weights.py tests/test_checkpoint_overlap.py`
- `git diff --check`

Fixes #75
