### PR TITLE
Derive safe image and batch output paths

### DIFF
--- a/bernini/io_utils.py
+++ b/bernini/io_utils.py
@@ -14,9 +14,28 @@
 
 """Write generated frames to disk as H.264 mp4 (or png for a single frame)."""
 
+import os
+
 import imageio
 import numpy as np
 from PIL import Image
+
+
+IMAGE_EXTENSIONS = {".bmp", ".gif", ".jpeg", ".jpg", ".png", ".tif", ".tiff", ".webp"}
+VIDEO_EXTENSIONS = {".avi", ".m4v", ".mkv", ".mov", ".mp4", ".webm"}
+
+
+def resolve_output_path(default_path, task_output=None, task_index=0, task_count=1):
+    """Choose a task output and avoid default-path collisions in a batch."""
+    output_path = task_output or default_path
+    if task_count > 1 and not task_output:
+        root, extension = os.path.splitext(output_path)
+        output_path = f"{root}_{task_index:04d}{extension}"
+    return output_path
+
+
+def _path_with_extension(path, extension):
+    return os.path.splitext(path)[0] + extension
 
 
 def _imageio_mimwrite_h264(frames_uint8, save_path, fps=16, quality=10, crf=8):
@@ -56,7 +75,11 @@ def export_to_video(video_frames, output_video_path, fps=16, quality=10, crf=8):
 def save_output(output: np.ndarray, save_path: str, fps: int = 16):
     """Save a decoded clip `[T, H, W, C]` in [0, 1] as mp4, or png if T == 1."""
     if output.shape[0] == 1:
+        if os.path.splitext(save_path)[1].lower() not in IMAGE_EXTENSIONS:
+            save_path = _path_with_extension(save_path, ".png")
         imageio.imwrite(save_path, (np.clip(output[0], 0.0, 1.0) * 255).astype(np.uint8))
     else:
+        if os.path.splitext(save_path)[1].lower() not in VIDEO_EXTENSIONS:
+            save_path = _path_with_extension(save_path, ".mp4")
         export_to_video(output, save_path, fps=fps)
     return save_path

--- a/bernini/pipeline.py
+++ b/bernini/pipeline.py
@@ -375,7 +375,7 @@ class BerniniRendererPipeline:
         torch.cuda.empty_cache()
 
         os.makedirs(os.path.dirname(os.path.abspath(output_path)), exist_ok=True)
-        save_output(output, output_path, fps=fps)
+        output_path = save_output(output, output_path, fps=fps)
         logger.info("saved -> %s  (%d frames, %dx%d)", output_path, output.shape[0], h, w)
         return output_path
 
@@ -1176,6 +1176,6 @@ class BerniniPipeline:
         torch.cuda.empty_cache()
 
         os.makedirs(os.path.dirname(os.path.abspath(output_path)), exist_ok=True)
-        save_output(output, output_path, fps=vae_fps)
+        output_path = save_output(output, output_path, fps=vae_fps)
         logger.info("saved -> %s  (%d frames, %dx%d)", output_path, output.shape[0], height, width)
         return output_path

--- a/infer_multi_gpu.py
+++ b/infer_multi_gpu.py
@@ -44,6 +44,7 @@ from bernini.cli import (
     resolve_system_prompt,
     setup_logging,
 )
+from bernini.io_utils import resolve_output_path
 from bernini.parallel import init_parallel_state
 from bernini.pipeline import BerniniPipeline
 
@@ -97,10 +98,15 @@ def main():
         rewriter = PromptEnhancer(model=args.pe_model)
 
     tasks = load_tasks(args)
-    my_tasks = tasks[ps.dp_rank :: ps.dp_size]  # data-parallel split across Ulysses groups
+    my_tasks = [
+        (task_index, task)
+        for task_index, task in enumerate(tasks)
+        if task_index % ps.dp_size == ps.dp_rank
+    ]
     common = generation_kwargs(args)
 
-    for task in my_tasks:
+    for task_index, task in my_tasks:
+        output_path = resolve_output_path(args.output, task.get("output"), task_index, len(tasks))
         prompt = rewrite_prompt(rewriter, task, args.task_type, ps)
         task_name = task.get("task_type", args.task_type)
         # BerniniPipeline takes task_name as first arg, BerniniRendererPipeline takes prompt
@@ -111,7 +117,7 @@ def main():
                 video=task.get("video"),
                 image=task.get("image"),
                 images=task.get("images"),
-                output_path=task.get("output", args.output),
+                output_path=output_path,
                 write_output=(ps.ulysses_rank == 0),
                 system_prompt=resolve_system_prompt(task, args),
                 **common,
@@ -122,7 +128,7 @@ def main():
                 video=task.get("video"),
                 image=task.get("image"),
                 images=task.get("images"),
-                output_path=task.get("output", args.output),
+                output_path=output_path,
                 write_output=(ps.ulysses_rank == 0),
                 system_prompt=resolve_system_prompt(task, args),
                 **common,

--- a/infer_single_gpu.py
+++ b/infer_single_gpu.py
@@ -38,6 +38,7 @@ from bernini.cli import (
     resolve_system_prompt,
     setup_logging,
 )
+from bernini.io_utils import resolve_output_path
 from bernini.pipeline import BerniniPipeline
 
 
@@ -59,7 +60,9 @@ def main():
         rewriter = PromptEnhancer(model=args.pe_model)
 
     common = generation_kwargs(args)
-    for task in load_tasks(args):
+    tasks = load_tasks(args)
+    for task_index, task in enumerate(tasks):
+        output_path = resolve_output_path(args.output, task.get("output"), task_index, len(tasks))
         prompt = task["prompt"]
         if rewriter is not None:
             prompt = rewriter(
@@ -78,7 +81,7 @@ def main():
                 video=task.get("video"),
                 image=task.get("image"),
                 images=task.get("images"),
-                output_path=task.get("output", args.output),
+                output_path=output_path,
                 system_prompt=resolve_system_prompt(task, args),
                 **common,
             )
@@ -88,7 +91,7 @@ def main():
                 video=task.get("video"),
                 image=task.get("image"),
                 images=task.get("images"),
-                output_path=task.get("output", args.output),
+                output_path=output_path,
                 system_prompt=resolve_system_prompt(task, args),
                 **common,
             )

--- a/tests/test_output_paths.py
+++ b/tests/test_output_paths.py
@@ -1,0 +1,80 @@
+"""Regression checks for image and batch output paths."""
+
+import importlib.util
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import numpy as np
+from PIL import Image
+
+
+SOURCE = Path(__file__).parents[1] / "bernini" / "io_utils.py"
+
+
+class OutputPathTests(unittest.TestCase):
+    def test_single_frame_mp4_default_is_written_as_a_real_png(self):
+        output = np.array(
+            [[[[0.0, 0.5, 1.0], [1.0, 0.0, 0.5]], [[0.25, 0.75, 0.0], [0.0, 1.0, 0.25]]]],
+            dtype=np.float32,
+        )
+        with self._load_io_utils() as io_utils:
+            with tempfile.TemporaryDirectory() as directory:
+                requested = str(Path(directory) / "output.mp4")
+
+                with mock.patch.object(
+                    io_utils.imageio, "imwrite", side_effect=self._write_png, create=True
+                ):
+                    actual = io_utils.save_output(output, requested)
+
+                self.assertEqual(Path(actual).suffix, ".png")
+                self.assertFalse(Path(requested).exists())
+                with Image.open(actual) as encoded:
+                    self.assertEqual(encoded.format, "PNG")
+                    self.assertEqual(encoded.size, (2, 2))
+                    self.assertEqual(encoded.getpixel((0, 0)), (0, 127, 255))
+
+    def test_batch_defaults_are_unique_but_explicit_outputs_are_preserved(self):
+        with self._load_io_utils() as io_utils:
+            self.assertEqual(
+                io_utils.resolve_output_path("outputs/output.mp4", None, 0, 2),
+                "outputs/output_0000.mp4",
+            )
+            self.assertEqual(
+                io_utils.resolve_output_path("outputs/output.mp4", None, 1, 2),
+                "outputs/output_0001.mp4",
+            )
+            self.assertEqual(
+                io_utils.resolve_output_path("outputs/output.mp4", "custom.mp4", 1, 2),
+                "custom.mp4",
+            )
+
+    @staticmethod
+    def _write_png(path, array):
+        Image.fromarray(array).save(path, format="PNG")
+
+    def _load_io_utils(self):
+        class ModuleLoader:
+            def __enter__(loader_self):
+                loader_self.previous_imageio = sys.modules.get("imageio", mock.sentinel.missing)
+                if loader_self.previous_imageio is mock.sentinel.missing:
+                    sys.modules["imageio"] = types.ModuleType("imageio")
+                spec = importlib.util.spec_from_file_location("bernini_test_io_utils", SOURCE)
+                loader_self.module = importlib.util.module_from_spec(spec)
+                sys.modules[spec.name] = loader_self.module
+                spec.loader.exec_module(loader_self.module)
+                return loader_self.module
+
+            def __exit__(loader_self, exc_type, exc_value, traceback):
+                sys.modules.pop("bernini_test_io_utils", None)
+                if loader_self.previous_imageio is mock.sentinel.missing:
+                    sys.modules.pop("imageio", None)
+
+        return ModuleLoader()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- derive `.png` for single-frame output and `.mp4` for multi-frame output when the requested extension is incompatible
- return the actual saved path from both pipeline implementations
- give batch tasks without explicit output paths stable index suffixes across single- and multi-GPU inference
- verify the single-frame path with a real PNG written through a local `imageio.imwrite` patch and reopened by Pillow

## Tests

- `python -B -m unittest tests/test_output_paths.py -v`
- Pillow verifies PNG format, dimensions, and pixel data from the temporary output
- `python -m compileall -q bernini/io_utils.py bernini/pipeline.py infer_single_gpu.py infer_multi_gpu.py tests/test_output_paths.py`
- `git diff --check`

Fixes #76
