### PR TITLE
Make renderer API checkpoint defaults safe

### DIFF
--- a/bernini/pipeline.py
+++ b/bernini/pipeline.py
@@ -220,9 +220,15 @@ class BerniniRendererPipeline:
         high_noise_ckpt: str = None,
         low_noise_ckpt: str = None,
         device="cuda",
-        load_ckpt_weights: bool = True,
+        load_ckpt_weights: bool = None,
         **config_overrides,
     ) -> "BerniniRendererPipeline":
+        if load_ckpt_weights is None:
+            if (high_noise_ckpt is None) != (low_noise_ckpt is None):
+                raise ValueError(
+                    "high_noise_ckpt and low_noise_ckpt must be provided together"
+                )
+            load_ckpt_weights = high_noise_ckpt is not None
         config = BerniniRendererConfig.from_pretrained(config_dir, **config_overrides)
         config.wan22_base = _prefer_local_dir(
             config.wan22_base, config_dir, "tokenizer", "text_encoder", "vae"

--- a/tests/test_pipeline_defaults.py
+++ b/tests/test_pipeline_defaults.py
@@ -1,0 +1,33 @@
+"""Regression checks for the renderer Python API checkpoint defaults."""
+
+import ast
+from pathlib import Path
+import unittest
+
+
+SOURCE = Path(__file__).parents[1] / "bernini" / "pipeline.py"
+
+
+class PipelineDefaultsTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.tree = ast.parse(SOURCE.read_text(encoding="utf-8"))
+        cls.method = next(
+            node
+            for node in ast.walk(cls.tree)
+            if isinstance(node, ast.FunctionDef)
+            and node.name == "from_pretrained"
+        )
+
+    def test_renderer_defaults_derive_diffusers_mode(self):
+        source = SOURCE.read_text(encoding="utf-8")
+        self.assertIn("load_ckpt_weights: bool = None", source)
+        self.assertIn("load_ckpt_weights = high_noise_ckpt is not None", source)
+        self.assertIn("high_noise_ckpt and low_noise_ckpt must be provided together", source)
+
+    def test_module_parses(self):
+        ast.parse(SOURCE.read_text(encoding="utf-8"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- derive `load_ckpt_weights` from the presence of a complete checkpoint pair when the API flag is omitted
- load the self-contained diffusers layout for a direct no-checkpoint API call
- reject an incomplete high/low checkpoint pair with a clear validation error
- add lightweight source/API regression checks

## Tests

- `python -B -m unittest tests/test_pipeline_defaults.py -v`
- `python -m compileall -q bernini/pipeline.py tests/test_pipeline_defaults.py`
- `git diff --check`

Fixes #79
